### PR TITLE
Fix paths to match current package server layout

### DIFF
--- a/pkg_tester.php
+++ b/pkg_tester.php
@@ -11,9 +11,10 @@ require_once("xmlrpc.inc");
 
 function get_firmware_version($return_php = true) {
         global $g;
-        $versioncheck_base_url = "www.pfsense.com";
-        $versioncheck_path = "/pfSense/xmlrpc.php";
+        $versioncheck_base_url = "packages.pfsense.org";
+        $versioncheck_path = "/xmlrpc.php";
 	$params = array(
+			"freebsd_version" => '10',
 			"pkg" => 'all',
 			"info" => array('version', 'name')
 			);

--- a/xmlrpc.php
+++ b/xmlrpc.php
@@ -121,7 +121,7 @@ function filter_versions($value) {
 }
 
 function get_pkgs($raw_params) {
-	$path_to_files = '../packages/';
+	$path_to_files = 'packages/';
 	$pkg_rootobj = 'pfsensepkgs';
 	$apkgs = array();
 	$toreturn = array();

--- a/xmlrpc_tester.php
+++ b/xmlrpc_tester.php
@@ -11,8 +11,8 @@ require_once("xmlrpc.inc");
 
 function get_firmware_version($return_php = true) {
         global $g;
-        $versioncheck_base_url = "www.pfsense.com";
-        $versioncheck_path = "/pfSense/xmlrpc.php";
+        $versioncheck_base_url = "packages.pfsense.org";
+        $versioncheck_path = "/xmlrpc.php";
         if(isset($config['system']['alt_firmware_url']['enabled']) and isset($config['system']['alt_firmware_url']['versioncheck_base_url'])) {
                 $versioncheck_base_url = $config['system']['alt_firmware_url']['versioncheck_base_url'];
         }


### PR DESCRIPTION
pkg_tester.php:
    Change server to packages.pfsense.org from www.pfsense.com.
    Eliminate pfSense subdirectory from path.
    Add freebsd_version parameter.

xmlrpc.php:
    Remove ../ from packages path.
